### PR TITLE
Add sensitivity analysis to robustness module

### DIFF
--- a/src/robustness.py
+++ b/src/robustness.py
@@ -1,3 +1,16 @@
+"""Utilities to evaluate robustness of an EVRP solution.
+
+The module provides two high level helpers:
+
+``robustness_analysis``
+    Estimates the stability of a solution under random demand and travel
+    time perturbations using a Monte Carlo approach.
+
+``sensitivity_analysis``
+    Computes simple measures of how sensitive the solution cost is to
+    changes in demand or travel time individually.
+"""
+
 import random
 import math
 import os
@@ -12,64 +25,53 @@ else:  # pragma: no cover - runtime path fix
     from src.solver import build_mats, score
 
 
-def robustness_analysis(solution: Dict[str, Any],
-                        nodes,
-                        links,
-                        requests,
-                        fleet,
-                        scenarios: int = 100,
-                        demand_std: float = 0.1,
-                        travel_time_std: float = 0.1) -> Dict[str, float]:
+def robustness_analysis(
+    solution: Dict[str, Any],
+    nodes,
+    links,
+    requests,
+    fleet,
+    scenarios: int = 100,
+    demand_std: float = 0.1,
+    travel_time_std: float = 0.1,
+) -> Dict[str, float]:
     """Evaluate solution robustness via Monte Carlo simulation.
 
-    Parameters
-    ----------
-    solution: dict
-        Solution returned by :func:`solve`.
-    nodes, links, requests, fleet:
-        Original problem data.
-    scenarios: int
-        Number of random scenarios to simulate.
-    demand_std: float
-        Standard deviation for Gaussian perturbation of customer demand
-        (relative to original load).
-    travel_time_std: float
-        Standard deviation for Gaussian perturbation of travel times
-        (relative to original time).
-
-    Returns
-    -------
-    dict with keys ``mean_cost``, ``std_cost``, ``min_cost``, ``max_cost``,
-    ``failure_rate`` and ``success_rate``. ``failure_rate`` indicates the
-    fraction of simulated scenarios in which the solution becomes infeasible,
-    while ``success_rate`` expresses the proportion of scenarios remaining
-    feasible.
+    This function perturbs customer demands and travel times according to
+    independent Gaussian noises and re-evaluates the solution cost.  The
+    distribution of the resulting costs is a measure for the robustness of
+    the provided solution.
     """
+
     base_demands = {r['node_id']: r['load'] for r in requests}
+    dist_base, mu_base, _ = build_mats(nodes, links)
 
     costs = []
     infeasible_count = 0
     penalty = 1e5
 
     for _ in range(scenarios):
-        perturbed_demands = {}
+        # --- perturb demands ---
+        demands = {}
         for nid, load in base_demands.items():
             noise = random.gauss(0.0, demand_std)
-            perturbed = max(0, load + int(round(load * noise)))
-            perturbed_demands[nid] = perturbed
+            demands[nid] = max(0, load + int(round(load * noise)))
 
-        perturbed_links = {}
-        for (i, j), data in links.items():
-            dist = data['distance'] if isinstance(data, dict) else data
-            tt = data.get('travel_time') if isinstance(data, dict) else None
-            if tt is None:
-                tt = dist / 40.0
-            tt *= max(0.0, 1.0 + random.gauss(0.0, travel_time_std))
-            perturbed_links[(i, j)] = {'distance': dist, 'travel_time': tt}
+        # --- perturb travel times ---
+        mu_mat = mu_base.copy()
+        for (i, j) in links.keys():
+            noise = random.gauss(0.0, travel_time_std)
+            mu_mat[i, j] = mu_base[i, j] * max(0.0, 1.0 + noise)
 
-        dist_mat, mu_mat, _ = build_mats(nodes, perturbed_links)
-        c = score(solution, dist_mat, perturbed_demands, mu_matrix=mu_mat,
-                  penalty_unserved=penalty, vehicles=fleet, nodes=nodes)
+        c = score(
+            solution,
+            dist_base,
+            demands,
+            mu_matrix=mu_mat,
+            penalty_unserved=penalty,
+            vehicles=fleet,
+            nodes=nodes,
+        )
         if c >= penalty:
             infeasible_count += 1  # count scenarios that violate constraints
         costs.append(c)
@@ -82,17 +84,86 @@ def robustness_analysis(solution: Dict[str, Any],
     success_rate = 1.0 - failure_rate
 
     return {
-        'mean_cost': mean_cost,
-        'std_cost': std_cost,
-        'min_cost': min(costs),
-        'max_cost': max(costs),
-        'failure_rate': failure_rate,
-        'success_rate': success_rate,
+        "mean_cost": mean_cost,
+        "std_cost": std_cost,
+        "min_cost": min(costs),
+        "max_cost": max(costs),
+        "failure_rate": failure_rate,
+        "success_rate": success_rate,
+    }
+
+
+def sensitivity_analysis(
+    solution: Dict[str, Any],
+    nodes,
+    links,
+    requests,
+    fleet,
+    scenarios: int = 100,
+    demand_std: float = 0.1,
+    travel_time_std: float = 0.1,
+) -> Dict[str, float]:
+    """Quantify solution sensitivity to demand and travel time changes.
+
+    Two separate Monte Carlo experiments are run: one perturbing only the
+    demands and another perturbing only the travel times.  The returned
+    values represent the average increase in cost compared to the base
+    scenario.
+    """
+
+    base_demands = {r['node_id']: r['load'] for r in requests}
+    dist_base, mu_base, _ = build_mats(nodes, links)
+    penalty = 1e5
+
+    base_cost = score(
+        solution,
+        dist_base,
+        base_demands,
+        mu_matrix=mu_base,
+        penalty_unserved=penalty,
+        vehicles=fleet,
+        nodes=nodes,
+    )
+
+    def mean_cost(perturb_demand: bool, perturb_time: bool) -> float:
+        costs = []
+        for _ in range(scenarios):
+            demands = base_demands.copy()
+            if perturb_demand:
+                for nid, load in base_demands.items():
+                    noise = random.gauss(0.0, demand_std)
+                    demands[nid] = max(0, load + int(round(load * noise)))
+
+            mu_mat = mu_base.copy()
+            if perturb_time:
+                for (i, j) in links.keys():
+                    noise = random.gauss(0.0, travel_time_std)
+                    mu_mat[i, j] = mu_base[i, j] * max(0.0, 1.0 + noise)
+
+            c = score(
+                solution,
+                dist_base,
+                demands,
+                mu_matrix=mu_mat,
+                penalty_unserved=penalty,
+                vehicles=fleet,
+                nodes=nodes,
+            )
+            costs.append(c)
+        return sum(costs) / len(costs)
+
+    demand_mean = mean_cost(True, False)
+    time_mean = mean_cost(False, True)
+
+    return {
+        "base_cost": base_cost,
+        "demand_sensitivity": demand_mean - base_cost,
+        "time_sensitivity": time_mean - base_cost,
     }
 
 
 def main(argv=None):
-    """Simple CLI for robustness analysis."""
+    """Simple CLI for robustness and sensitivity analysis."""
     import argparse
     if __package__:
         from .file_solver import build_problem
@@ -101,23 +172,65 @@ def main(argv=None):
         from src.file_solver import build_problem
         from src.solver import solve
 
-    parser = argparse.ArgumentParser(description='Robustness analysis for EVRP solutions')
-    parser.add_argument('instance', help='Path to .evrp instance file')
-    parser.add_argument('--iterations', type=int, default=500, help='ALNS iterations to generate solution')
-    parser.add_argument('--scenarios', type=int, default=100, help='Number of perturbation scenarios')
-    parser.add_argument('--demand-std', type=float, default=0.1, help='Std dev for demand perturbation (relative)')
-    parser.add_argument('--time-std', type=float, default=0.1, help='Std dev for travel time perturbation (relative)')
+    parser = argparse.ArgumentParser(
+        description="Robustness analysis for EVRP solutions"
+    )
+    parser.add_argument("instance", help="Path to .evrp instance file")
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=500,
+        help="ALNS iterations to generate solution",
+    )
+    parser.add_argument(
+        "--scenarios", type=int, default=100, help="Number of perturbation scenarios"
+    )
+    parser.add_argument(
+        "--demand-std",
+        type=float,
+        default=0.1,
+        help="Std dev for demand perturbation (relative)",
+    )
+    parser.add_argument(
+        "--time-std",
+        type=float,
+        default=0.1,
+        help="Std dev for travel time perturbation (relative)",
+    )
     args = parser.parse_args(argv)
 
     nodes, links, requests, fleet = build_problem(args.instance)
-    solution, _ = solve(nodes, links, requests, fleet, iterations=args.iterations)
-    metrics = robustness_analysis(solution, nodes, links, requests, fleet,
-                                  scenarios=args.scenarios,
-                                  demand_std=args.demand_std,
-                                  travel_time_std=args.time_std)
+    solution, _ = solve(
+        nodes, links, requests, fleet, iterations=args.iterations
+    )
+
+    metrics = robustness_analysis(
+        solution,
+        nodes,
+        links,
+        requests,
+        fleet,
+        scenarios=args.scenarios,
+        demand_std=args.demand_std,
+        travel_time_std=args.time_std,
+    )
+
+    sens = sensitivity_analysis(
+        solution,
+        nodes,
+        links,
+        requests,
+        fleet,
+        scenarios=args.scenarios,
+        demand_std=args.demand_std,
+        travel_time_std=args.time_std,
+    )
+
     for k, v in metrics.items():
+        print(f"{k}: {v}")
+    for k, v in sens.items():
         print(f"{k}: {v}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- streamline robustness simulation by reusing base matrices
- add dedicated sensitivity analysis for demand and travel-time variations
- expose both analyses via the command-line interface

## Testing
- `python -m py_compile src/robustness.py`
- `python - <<'PY'
from src.robustness import robustness_analysis, sensitivity_analysis
nodes = [{'id':0,'type':'depot'},{'id':1,'type':'customer'},{'id':2,'type':'customer'}]
links = {(0,1): {'distance':10,'travel_time':0.25}, (1,0): {'distance':10,'travel_time':0.25}, (0,2): {'distance':20,'travel_time':0.5}, (2,0):{'distance':20,'travel_time':0.5}, (1,2):{'distance':15,'travel_time':0.375}, (2,1):{'distance':15,'travel_time':0.375}}
requests=[{'node_id':1,'load':5},{'node_id':2,'load':3}]
fleet=[{'max_load_capacity':20,'max_energy_capacity':100,'consumption_per_km':0.2,'quantity':1}]
solution={'routes':[[0,1,2,0]],'unassigned':[],'depot':0}
print('robust', robustness_analysis(solution,nodes,links,requests,fleet,scenarios=10))
print('sens', sensitivity_analysis(solution,nodes,links,requests,fleet,scenarios=10))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ab2d542dfc8327b29546de0824fa8e