### PR TITLE
Add genetic algorithm solver with selectable backends and clearer plots

### DIFF
--- a/src/ga_solver.py
+++ b/src/ga_solver.py
@@ -1,0 +1,175 @@
+import random
+from typing import List, Dict, Tuple, Optional
+
+import numpy as np
+
+
+def _expand_fleet(fleet: List[Dict]) -> List[Dict]:
+    """Expand fleet definitions into individual vehicles."""
+    vehicles = []
+    for v in fleet:
+        qty = int(v.get("quantity", 1))
+        for _ in range(qty):
+            vehicles.append(
+                {
+                    "capacity": float(v.get("max_load_capacity", 0)),
+                    "energy": float(v.get("max_energy_capacity", 0)),
+                    "consumption": float(v.get("consumption_per_km", 0.0)),
+                }
+            )
+    if not vehicles:
+        vehicles.append({"capacity": 0.0, "energy": 0.0, "consumption": 0.0})
+    return vehicles
+
+
+def _distance_matrix(n: int, links: Dict[Tuple[int, int], Dict]) -> np.ndarray:
+    """Build dense distance matrix from links mapping."""
+    big = 1e9
+    dist = np.full((n, n), big, dtype=float)
+    for i in range(n):
+        dist[i, i] = 0.0
+    for (i, j), data in links.items():
+        d = data["distance"] if isinstance(data, dict) else float(data)
+        dist[i, j] = d
+        if dist[j, i] >= big:
+            dist[j, i] = d
+    return dist
+
+
+def _build_routes(
+    perm: List[int],
+    vehicles: List[Dict],
+    depot: int,
+    dist: np.ndarray,
+    demand: Dict[int, int],
+) -> Tuple[List[List[int]], List[int], float]:
+    """Construct routes from a customer permutation.
+
+    Returns routes, unassigned customers and total distance.
+    """
+    routes: List[List[int]] = []
+    unassigned: List[int] = []
+    idx = 0
+    customers = len(perm)
+
+    for veh in vehicles:
+        load = 0.0
+        energy = veh["energy"]
+        cons = veh["consumption"]
+        route = [depot]
+        current = depot
+        while idx < customers:
+            cust = perm[idx]
+            d = demand[cust]
+            dist_to = dist[current, cust]
+            dist_back = dist[cust, depot]
+            need_energy = cons * (dist_to + dist_back)
+            if load + d <= veh["capacity"] and energy >= need_energy:
+                # accept customer
+                route.append(cust)
+                load += d
+                energy -= cons * dist_to
+                current = cust
+                idx += 1
+            else:
+                break
+        if len(route) > 1:
+            route.append(depot)
+            routes.append(route)
+        if idx >= customers:
+            break
+
+    if idx < customers:
+        unassigned.extend(perm[idx:])
+
+    cost = 0.0
+    for r in routes:
+        for i in range(len(r) - 1):
+            cost += dist[r[i], r[i + 1]]
+    return routes, unassigned, cost
+
+
+def solve_ga(
+    nodes: List[Dict],
+    links: Dict[Tuple[int, int], Dict],
+    requests: List[Dict],
+    fleet: List[Dict],
+    population_size: int = 50,
+    generations: int = 200,
+    mutation_rate: float = 0.1,
+) -> Tuple[Dict, float]:
+    """Solve the EVRP using a simple genetic algorithm.
+
+    The returned solution has the same structure as solver.solve or
+    ortools_solver.solve_ortools.
+    """
+    n = len(nodes)
+    depot = next((n["id"] for n in nodes if n.get("type") == "depot"), 0)
+    dist = _distance_matrix(n, links)
+    vehicles = _expand_fleet(fleet)
+
+    demand = {r["node_id"]: int(r.get("load", 0)) for r in requests}
+    customers = list(demand.keys())
+    if not customers:
+        sol = {"routes": [], "unassigned": [], "vehicles": vehicles, "depot": depot}
+        return sol, 0.0
+
+    def evaluate(perm: List[int]):
+        routes, unassigned, cost = _build_routes(perm, vehicles, depot, dist, demand)
+        penalty = 1e6 * len(unassigned)
+        return cost + penalty, routes, unassigned
+
+    # initial population
+    population: List[List[int]] = []
+    for _ in range(population_size):
+        p = customers[:]
+        random.shuffle(p)
+        population.append(p)
+
+    best_cost = float("inf")
+    best_routes: Optional[List[List[int]]] = None
+    best_unassigned: Optional[List[int]] = None
+
+    for _ in range(generations):
+        scored = []
+        for perm in population:
+            cost, routes, unassigned = evaluate(perm)
+            scored.append((cost, perm, routes, unassigned))
+            if cost < best_cost:
+                best_cost = cost
+                best_routes = routes
+                best_unassigned = unassigned
+        scored.sort(key=lambda x: x[0])
+        survivors = [perm for _, perm, _, _ in scored[: max(2, population_size // 2)]]
+
+        offspring: List[List[int]] = []
+        while len(offspring) + len(survivors) < population_size:
+            parent1, parent2 = random.sample(survivors, 2)
+            if len(customers) < 2:
+                child = parent1[:]
+            else:
+                cut1, cut2 = sorted(random.sample(range(len(customers)), 2))
+                child = [None] * len(customers)
+                child[cut1:cut2] = parent1[cut1:cut2]
+                fill = [c for c in parent2 if c not in child]
+                it = iter(fill)
+                for i in range(len(customers)):
+                    if child[i] is None:
+                        child[i] = next(it)
+            if random.random() < mutation_rate and len(customers) >= 2:
+                i, j = random.sample(range(len(customers)), 2)
+                child[i], child[j] = child[j], child[i]
+            offspring.append(child)
+        population = survivors + offspring
+
+    if best_routes is None:
+        best_routes = []
+    if best_unassigned is None:
+        best_unassigned = customers
+    solution = {
+        "routes": best_routes,
+        "unassigned": best_unassigned,
+        "vehicles": vehicles,
+        "depot": depot,
+    }
+    return solution, best_cost

--- a/src/plot.py
+++ b/src/plot.py
@@ -23,6 +23,10 @@ plt.rcParams.update(
 def plot_sol(sol_path, out_path=None, show=False, figsize=(10, 8)):
     """Plot a solution JSON file and save a high-quality image.
 
+    The plot highlights each route in a different color and numbers
+    customer visits in the order they are served so the viewer can follow
+    the tour like a story.
+
     Parameters
     ----------
     sol_path : str
@@ -59,7 +63,7 @@ def plot_sol(sol_path, out_path=None, show=False, figsize=(10, 8)):
     fig, ax = plt.subplots(figsize=figsize)
     cmap = plt.get_cmap('tab10')
 
-    # plot each route
+    # plot each route with visit order annotations
     for i, route in enumerate(routes):
         if not route:
             continue
@@ -68,11 +72,21 @@ def plot_sol(sol_path, out_path=None, show=False, figsize=(10, 8)):
             continue
         pts = np.vstack(pts)
         color = cmap(i % 10)
-        ax.plot(pts[:, 0], pts[:, 1], '-', color=color, linewidth=2, alpha=0.8, label=f'Route {i+1}')
-        ax.scatter(pts[1:-1, 0] if len(pts) > 2 else [], pts[1:-1, 1] if len(pts) > 2 else [], c=[color], s=30)
+        ax.plot(pts[:, 0], pts[:, 1], '-', color=color, linewidth=2, alpha=0.8,
+                label=f'Route {i+1}')
+        # plot intermediate customer points
+        if len(pts) > 2:
+            ax.scatter(pts[1:-1, 0], pts[1:-1, 1], c=[color], s=30)
         # mark route start and end
         ax.scatter(pts[0, 0], pts[0, 1], c='k', marker='s', s=60, zorder=5)
         ax.scatter(pts[-1, 0], pts[-1, 1], c='k', marker='o', s=60, zorder=5)
+        # annotate step numbers to tell a story of the tour
+        for step, node in enumerate(route[1:-1], start=1):
+            nid = int(node)
+            if nid in coord_map:
+                x, y = coord_map[nid]
+                ax.annotate(str(step), (x, y), textcoords="offset points",
+                            xytext=(3, 3), fontsize=8, color=color)
 
     # plot depot
     if depot_id in coord_map:


### PR DESCRIPTION
## Summary
- allow running ALNS, OR-Tools, or GA solvers individually or together via command line
- prefix console and file outputs with solver name for easy comparison
- enhance plotting to number customer visits for story-like route visualization

## Testing
- `python -m py_compile src/solver.py src/plot.py src/ga_solver.py`
- `python src/solver.py --instance data/E-n29-k4-s7.evrp --solver ga,alns --iterations 1`
- `python -u src/plot.py --solution output/solution_ga.json --out output/solution_ga_plot2.png`


------
https://chatgpt.com/codex/tasks/task_e_68b066a4185c8327b4770f43184b6923